### PR TITLE
Decreasing disk stress and processing time of the contig step by repl…

### DIFF
--- a/templates/contig/RGCRG-ANTISENSE
+++ b/templates/contig/RGCRG-ANTISENSE
@@ -1,12 +1,13 @@
 #!/bin/bash -eu
-samtools view -h -@ ${cpus} ${bam} | \
-awk 'BEGIN {OFS="\\t"} {if (\$1!~/^@/) {\$2=xor(\$2,0x10)}; print}' | \
-samtools view -@ ${cpus} -Sb - > tmp.bam
-
-bamtools filter -tag NH:1 -in tmp.bam -out tmp_unique.bam && rm tmp.bam
-genomeCoverageBed -strand + -split -bg -ibam tmp_unique.bam > ${prefix}.plusRaw.bedgraph
-genomeCoverageBed -strand - -split -bg -ibam tmp_unique.bam > ${prefix}.minusRaw.bedgraph
-rm tmp_unique.bam
+samtools view -h -@ ${cpus} ${bam} \
+  | awk 'BEGIN {OFS="\\t"} {if (\$1!~/^@/) {\$2=xor(\$2,0x10)}; print}' \
+  | samtools view -Sbu - \
+  | tee >(
+      genomeCoverageBed -strand + -split -bg -ibam - \
+      > ${prefix}.contigs.plusRaw.bedgraph
+    ) \
+  | genomeCoverageBed -strand - -split -bg -ibam - \
+> ${prefix}.contigs.minusRaw.bedgraph
 
 contigsNew.py --chrFile ${genomeFai} \
               --fileP ${prefix}.plusRaw.bedgraph \

--- a/templates/contig/RGCRG-MATE1_SENSE
+++ b/templates/contig/RGCRG-MATE1_SENSE
@@ -1,12 +1,17 @@
 #!/bin/bash -eu
-samtools view -h -@ ${cpus} ${bam} | \
-awk 'BEGIN {OFS="\\t"} {if (\$1!~/^@/ && and(\$2,128)>0) {\$2=xor(\$2,0x10)}; print}' | \
-samtools view -@ ${cpus} -Sb - > tmp.bam
-
-bamtools filter -tag NH:1 -in tmp.bam -out tmp_unique.bam && rm tmp.bam
-genomeCoverageBed -strand + -split -bg -ibam tmp_unique.bam > ${prefix}.plusRaw.bedgraph
-genomeCoverageBed -strand - -split -bg -ibam tmp_unique.bam > ${prefix}.minusRaw.bedgraph
-rm tmp_unique.bam
+samtools view -h -@ ${cpus} ${bam} \
+  | awk '
+      BEGIN {OFS="\\t"} 
+      {if (\$1!~/^@/ && and(\$2,128)>0) {\$2=xor(\$2,0x10)}; print}
+    ' \
+  | samtools view -Sbu - \
+  | bamtools filter -tag NH:1 \
+  | tee >(
+      genomeCoverageBed -strand + -split -bg -ibam - \
+      > ${prefix}.plusRaw.bedgraph
+    ) \
+  | genomeCoverageBed -strand - -split -bg -ibam - \
+> ${prefix}.minusRaw.bedgraph
 
 contigsNew.py --chrFile ${genomeFai} \
               --fileP ${prefix}.plusRaw.bedgraph \

--- a/templates/contig/RGCRG-MATE2_SENSE
+++ b/templates/contig/RGCRG-MATE2_SENSE
@@ -1,12 +1,17 @@
 #!/bin/bash -eu
-samtools view -h -@ ${cpus} ${bam} | \
-awk 'BEGIN {OFS="\\t"} {if (\$1!~/^@/ && and(\$2,64)>0) {\$2=xor(\$2,0x10)}; print}' | \
-samtools view -@ ${cpus} -Sb - > tmp.bam
-
-bamtools filter -tag NH:1 -in tmp.bam -out tmp_unique.bam && rm tmp.bam
-genomeCoverageBed -strand + -split -bg -ibam tmp_unique.bam > ${prefix}.plusRaw.bedgraph
-genomeCoverageBed -strand - -split -bg -ibam tmp_unique.bam > ${prefix}.minusRaw.bedgraph
-rm tmp_unique.bam
+samtools view -h -@ ${cpus} ${bam} \
+  | awk '
+      BEGIN {OFS="\\t"} 
+      {if (\$1!~/^@/ && and(\$2,64)>0) {\$2=xor(\$2,0x10)}; print}
+    ' \
+  | samtools view -Sbu \
+  | bamtools filter -tag NH:1 \
+  | tee >(
+      genomeCoverageBed -strand + -split -bg -ibam - \
+      > ${prefix}.plusRaw.bedgraph
+    ) \
+  | genomeCoverageBed -strand - -split -bg -ibam - \
+> ${prefix}.minusRaw.bedgraph
 
 contigsNew.py --chrFile ${genomeFai} \
               --fileP ${prefix}.plusRaw.bedgraph \

--- a/templates/contig/RGCRG-NONE
+++ b/templates/contig/RGCRG-NONE
@@ -1,4 +1,6 @@
 #!/bin/bash -eu
-bamtools filter -tag NH:1 -in ${bam} -out tmp_unique.bam
-bamToBed -i tmp_unique.bam | sort -T. -k1,1 -k2,2n | mergeBed > ${prefix}.bed
-rm tmp_unique.bam
+bamtools filter -tag NH:1 -in ${bam} \
+  | bamToBed -i - \
+  | sort -T. -k1,1 -k2,2n \
+  | mergeBed \
+> ${prefix}.bed

--- a/templates/contig/RGCRG-SENSE
+++ b/templates/contig/RGCRG-SENSE
@@ -1,8 +1,11 @@
 #!/bin/bash -eu
-bamtools filter -tag NH:1 -in ${bam} -out tmp_unique.bam
-genomeCoverageBed -strand + -split -bg -ibam tmp_unique.bam > ${prefix}.plusRaw.bedgraph
-genomeCoverageBed -strand - -split -bg -ibam tmp_unique.bam > ${prefix}.minusRaw.bedgraph
-rm tmp_unique.bam
+bamtools filter -tag NH:1 -in ${bam} \
+  | tee >(
+      genomeCoverageBed -strand + -split -bg -ibam - \
+      > ${prefix}.plusRaw.bedgraph
+    ) \
+  | genomeCoverageBed -strand - -split -bg -ibam - \
+> ${prefix}.minusRaw.bedgraph
 
 contigsNew.py --chrFile ${genomeFai} \
               --fileP ${prefix}.plusRaw.bedgraph \


### PR DESCRIPTION
Decreasing disk stress and processing time of the contig step by replacing temporary bam files by pipes. The drawback is that it is harder to control the maximum number of used cores.

The piped version of RGCRG-ANTISENSE ran ~9m on 2.4G mouse reads compared to ~25m for the original version. Timing/testing was done without the python script and running it without nextflow. The resulting *.bedgraph files were identical.