### PR TITLE
modified quantification step by removing the temporary sorted bam fil…

### DIFF
--- a/templates/quantification/RSEM-Paired-End-MATE1_SENSE
+++ b/templates/quantification/RSEM-Paired-End-MATE1_SENSE
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
-samtools sort -@ ${cpus} -ni -O bam -T . -o tmp_query_sorted.bam ${bam}
-
-rsem-calculate-expression --bam \
+samtools sort -@ ${cpus} -ni -O sam -T . ${bam} \
+  | rsem-calculate-expression --sam \
                           --estimate-rspd  \
                           --calc-ci \
                           --no-bam-output \
@@ -10,8 +9,8 @@ rsem-calculate-expression --bam \
                           --ci-memory ${memory} \
                           --paired-end \
                           --forward-prob 1 \
-                          tmp_query_sorted.bam \
+                          - \
                           ${quantRef}/RSEMref \
                           ${prefix}
-rm tmp_query_sorted.bam                          
+
 rsem-plot-model ${prefix} ${prefix}.pdf

--- a/templates/quantification/RSEM-Paired-End-MATE2_SENSE
+++ b/templates/quantification/RSEM-Paired-End-MATE2_SENSE
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
-samtools sort -@ ${cpus} -ni -O bam -T . -o tmp_query_sorted.bam ${bam}
-
-rsem-calculate-expression --bam \
+samtools sort -@ ${cpus} -ni -O sam -T . ${bam} \
+  | rsem-calculate-expression --sam \
                           --estimate-rspd  \
                           --calc-ci \
                           --no-bam-output \
@@ -10,8 +9,8 @@ rsem-calculate-expression --bam \
                           --ci-memory ${memory} \
                           --paired-end \
                           --forward-prob 0 \
-                          tmp_query_sorted.bam \
+                          - \
                           ${quantRef}/RSEMref \
                           ${prefix}
-rm tmp_query_sorted.bam                          
+
 rsem-plot-model ${prefix} ${prefix}.pdf

--- a/templates/quantification/RSEM-Paired-End-NONE
+++ b/templates/quantification/RSEM-Paired-End-NONE
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
-samtools sort -@ ${cpus} -ni -O bam -T . -o tmp_query_sorted.bam ${bam}
-
-rsem-calculate-expression --bam \
+samtools sort -@ ${cpus} -ni -O sam -T . ${bam} \
+  | rsem-calculate-expression --sam \
                           --estimate-rspd  \
                           --calc-ci \
                           --no-bam-output \
@@ -12,5 +11,5 @@ rsem-calculate-expression --bam \
                           tmp_query_sorted.bam \
                           ${quantRef}/RSEMref \
                           ${prefix}
-rm tmp_query_sorted.bam                          
+
 rsem-plot-model ${prefix} ${prefix}.pdf

--- a/templates/quantification/RSEM-Single-End-ANTISENSE
+++ b/templates/quantification/RSEM-Single-End-ANTISENSE
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
-samtools sort -@ ${cpus} -ni -O bam -T . -o tmp_query_sorted.bam ${bam}
-
-rsem-calculate-expression --bam \
+samtools sort -@ ${cpus} -ni -O sam -T . ${bam} \
+  | rsem-calculate-expression --sam \
                           --estimate-rspd  \
                           --calc-ci \
                           --no-bam-output \
@@ -12,5 +11,5 @@ rsem-calculate-expression --bam \
                           tmp_query_sorted.bam \
                           ${quantRef}/RSEMref \
                           ${prefix}
-rm tmp_query_sorted.bam
+
 rsem-plot-model ${prefix} ${prefix}.pdf

--- a/templates/quantification/RSEM-Single-End-NONE
+++ b/templates/quantification/RSEM-Single-End-NONE
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
-samtools sort -@ ${cpus} -ni -O bam -T . -o tmp_query_sorted.bam ${bam}
-
-rsem-calculate-expression --bam \
+samtools sort -@ ${cpus} -ni -O sam -T . ${bam} \
+  | rsem-calculate-expression --sam \
                           --estimate-rspd  \
                           --calc-ci \
                           --no-bam-output \
@@ -11,5 +10,5 @@ rsem-calculate-expression --bam \
                           tmp_query_sorted.bam \
                           ${quantRef}/RSEMref \
                           ${prefix}
-rm tmp_query_sorted.bam                          
+
 rsem-plot-model ${prefix} ${prefix}.pdf

--- a/templates/quantification/RSEM-Single-End-SENSE
+++ b/templates/quantification/RSEM-Single-End-SENSE
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
-samtools sort -@ ${cpus} -ni -O bam -T . -o tmp_query_sorted.bam ${bam}
-
-rsem-calculate-expression --bam \
+samtools sort -@ ${cpus} -ni -O sam -T . ${bam} \
+  | rsem-calculate-expression --sam \
                           --estimate-rspd  \
                           --calc-ci \
                           --no-bam-output \
@@ -12,5 +11,5 @@ rsem-calculate-expression --bam \
                           tmp_query_sorted.bam \
                           ${quantRef}/RSEMref \
                           ${prefix}
-rm tmp_query_sorted.bam                          
+
 rsem-plot-model ${prefix} ${prefix}.pdf


### PR DESCRIPTION
…e. By doing this we can pipe an uncompressed sam file directly to rsem. The pipe itself saves us the time it takes to write and read the fileto/from disk. I assume sam format is faster as it avoids one compression and one decompression step... but this wasn't tested...

The cpu load should be limited by disk, but as it stands 2xcpu is reserved at a single time point as samtools and rsem runs in parallel.

History: I wanted to downsample a library and found yet another potential speed-up/disk-saver